### PR TITLE
Enable pedantic Clippy linting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@
 //! println!("Cost: ${:.2}", meeting.total_cost());
 //! ```
 
+#![warn(clippy::pedantic)]
+
 mod meeting;
 mod model;
 mod storage;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 //! Interactive terminal application for tracking meeting costs.
 // main.rs
+#![warn(clippy::pedantic)]
 
 use std::{error::Error, path::PathBuf, time::Duration};
 


### PR DESCRIPTION
## Summary
- warn about pedantic Clippy lints for library and binary

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6873d48c37548327b31992bde4cb34fc